### PR TITLE
fix indentation

### DIFF
--- a/source/docs/user_manual/working_with_vector/vector_properties.rst
+++ b/source/docs/user_manual/working_with_vector/vector_properties.rst
@@ -744,7 +744,8 @@ features of the layer:
   :menuselection:`Customize effects` button (the small "star" shape, on the right
   of the :menuselection:`Draw effects` button).
   The effects include the following categories, with the following options:
-    * **Blur:** Adds a blur effect on the vector layer. The options that someone
+  
+  * **Blur:** Adds a blur effect on the vector layer. The options that someone
     can change are the :menuselection:`Blur type` (:menuselection:`Stack` or
     :menuselection:`Gaussian blur`), the strength and transparency of the blur
     effect.
@@ -752,11 +753,11 @@ features of the layer:
     **Figure Symbology 8:**
 
     .. figure:: /static/user_manual/working_with_vector/blur.png
-      :align: center
+       :align: center
 
-      Draw Effects: Blur dialog
+       Draw Effects: Blur dialog
 
-    * **Colorize:** This effect can be used by someone who wants to adjust the
+  * **Colorize:** This effect can be used by someone who wants to adjust the
     :menuselection:`brightness`, :menuselection:`contrast` and :menuselection:`saturation`
     levels of the feature. It, also, offers the option to overlay another color
     and mix it with the feature's current one. By default, the :menuselection:`grayscale`
@@ -766,21 +767,21 @@ features of the layer:
     **Figure Symbology 9:**
 
     .. figure:: /static/user_manual/working_with_vector/colorise.png
-      :align: center
+       :align: center
 
-      Draw Effects: Colorize dialog
+       Draw Effects: Colorize dialog
 
-    * **Source:** Implements the feature in the drawing menu, with its style as
-      selected in the layer properties. The transparency of its style can be adjusted.
+  * **Source:** Implements the feature in the drawing menu, with its style as
+    selected in the layer properties. The transparency of its style can be adjusted.
 
-      **Figure Symbology 10:**
+    **Figure Symbology 10:**
 
-      .. figure:: /static/user_manual/working_with_vector/source.png
-        :align: center
+    .. figure:: /static/user_manual/working_with_vector/source.png
+       :align: center
 
-        Draw Effects: Source dialog
+       Draw Effects: Source dialog
 
-    * **Drop Shadow:** Using this effect adds a shadow on the feature, which looks
+  * **Drop Shadow:** Using this effect adds a shadow on the feature, which looks
     like adding an extra dimension. This effect can be customized by changing the
     :menuselection:`offset` degrees and radius, determining where the shadow shifts
     towards to and the proximity to the source object. :menuselection:`Drop Shadow`
@@ -790,11 +791,11 @@ features of the layer:
     **Figure Symbology 11:**
 
     .. figure:: /static/user_manual/working_with_vector/drop_shadow.png
-      :align: center
+       :align: center
 
-      Draw Effects: Drop Shadow dialog
+       Draw Effects: Drop Shadow dialog
 
-    * **Inner Glow:** Adds a glow effect inside the feature. This effect can be
+  * **Inner Glow:** Adds a glow effect inside the feature. This effect can be
     customized by adjusting the :menuselection:`spread` (width) of the glow, or the
     :menuselection:`Blur radius`. The latter specifies the proximity from the edge
     of the feature where you want any blurring to happen. Additionally, there are
@@ -804,11 +805,11 @@ features of the layer:
     **Figure Symbology 12:**
 
     .. figure:: /static/user_manual/working_with_vector/inner_glow.png
-      :align: center
+       :align: center
 
-      Draw Effects: Inner Glow dialog
+       Draw Effects: Inner Glow dialog
 
-    * **Inner Shadow:** This effect is similar to the :menuselection:`Drop Shadow` effect,
+  * **Inner Shadow:** This effect is similar to the :menuselection:`Drop Shadow` effect,
     but it adds the shadow effect on the inside of the edges of the feature. The
     available options for customization are the same as the :menuselection:`Drop Shadow`
     effect.
@@ -816,11 +817,11 @@ features of the layer:
     **Figure Symbology 13:**
 
     .. figure:: /static/user_manual/working_with_vector/inner_shadow.png
-      :align: center
+       :align: center
 
-      Draw Effects: Inner Shadow dialog
+       Draw Effects: Inner Shadow dialog
 
-    * **Outer Glow:** This effect is similar to the :menuselection:`Inner Glow` effect,
+  * **Outer Glow:** This effect is similar to the :menuselection:`Inner Glow` effect,
     but it adds the glow effect on the outside of the edges of the feature. The
     available options for customization are the same as the :menuselection:`Inner Glow`
     effect.
@@ -828,11 +829,11 @@ features of the layer:
     **Figure Symbology 14:**
 
     .. figure:: /static/user_manual/working_with_vector/outer_glow.png
-      :align: center
+       :align: center
 
-      Draw Effects: Outer Glow dialog
+       Draw Effects: Outer Glow dialog
 
-    * **Transform:** Adds the possibility of transforming the shape of the source
+  * **Transform:** Adds the possibility of transforming the shape of the source
     feature. The first options available for customization are the :menuselection:`Reflect horizontal`
     and :menuselection:`Reflect horizontal`, which actually create a reflection on the
     horizontal and/or vertical axes. The 4 other options are the :menuselection:`Shear`,
@@ -846,17 +847,17 @@ features of the layer:
     **Figure Symbology 15:**
 
     .. figure:: /static/user_manual/working_with_vector/transform.png
-      :align: center
+       :align: center
 
-      Draw Effects: Transform dialog
-
-    In each of the Draw effect types, the :menuselection:`Blend mode` and :menuselection:`Draw mode`
-    can be adjusted to match the user needs. The Blend mode follows the same methods as the ones
-    included for the layers (link here) and cannot be used for the transform effect.
-    You can find more information in the :ref:`blend-modes`.
-    The Draw mode can apply a render and/or modify mode for each of the effects.
-    One or more draw effects can be selected at the same time, which can also be
-    moved up and down, in order to finally get the desired result.
+       Draw Effects: Transform dialog
+       
+  In each of the Draw effect types, the :menuselection:`Blend mode` and :menuselection:`Draw mode`
+  can be adjusted to match the user needs. The Blend mode follows the same methods as the ones
+  included for the layers (link here) and cannot be used for the transform effect.
+  You can find more information in the :ref:`blend-modes`.
+  The Draw mode can apply a render and/or modify mode for each of the effects.
+  One or more draw effects can be selected at the same time, which can also be
+  moved up and down, in order to finally get the desired result.
 
 * :guilabel:`Control feature rendering order` allows you to define, using features
   attributes, the order in which they shall be processed by the renderer.


### PR DESCRIPTION
@purplexed Hope this PR fixes your issue.
As you can see, alignment (and spacing and blank line) is the key.  when listing items:
- the first \* character is aligned with the upper level, then follows a space and the text of this item
- If the text is multiline, then following lines are aligned with the beginning of the text not with the \* character
- next items in the list have their first caharcter aligned with the first one...

You may find instructive information in http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
What I'm in doubt with in this PR is about images alignment
